### PR TITLE
Adds 10 second timeout to requests made to monday.

### DIFF
--- a/moncli/api_v1/requests.py
+++ b/moncli/api_v1/requests.py
@@ -1,4 +1,5 @@
 from moncli.routes import MondayQueryParameters, format_url, raise_mondayapi_error
+from .. import constants
 import requests, json
 
 
@@ -11,7 +12,8 @@ def execute_get(api_key, resource_url, params = None):
 
     resp = requests.get(
         format_url(resource_url), 
-        params=monday_params.to_dict())
+        params=monday_params.to_dict(),
+        timeout=constants.TIMEOUT)
 
     if resp.status_code == 200:
         return resp.json()
@@ -26,7 +28,8 @@ def execute_post(api_key, resource_url, body):
     resp = requests.post(
         format_url(resource_url),
         body,
-        params=monday_params.to_dict())
+        params=monday_params.to_dict(),
+        timeout=constants.TIMEOUT)
 
     if resp.status_code == 200 or resp.status_code == 201:
         return resp.json()
@@ -43,7 +46,8 @@ def execute_put(api_key, resource_url, body):
     resp = requests.post(
         format_url(resource_url),
         data,
-        params=monday_params.to_dict())
+        params=monday_params.to_dict(),
+        timeout=constants.TIMEOUT)
 
     if resp.status_code == 200:
         return resp.json()
@@ -60,7 +64,8 @@ def execute_delete(api_key, resource_url, params = None):
 
     resp = requests.delete(
         format_url(resource_url), 
-        params=monday_params.to_dict())
+        params=monday_params.to_dict(),
+        timeout=constants.TIMEOUT)
 
     if resp.status_code == 200:
         return resp.json()

--- a/moncli/api_v2/requests.py
+++ b/moncli/api_v2/requests.py
@@ -21,7 +21,8 @@ def execute_query(api_key: str, **kwargs):
     resp = requests.post(
         constants.API_V2_ENDPOINT,
         headers=headers,
-        data=data)
+        data=data,
+        timeout=constants.TIMEOUT)
 
     text: dict = resp.json()
 

--- a/moncli/constants.py
+++ b/moncli/constants.py
@@ -1,6 +1,8 @@
 DATE_FORMAT = '%Y-%m-%d'
 DATETIME_FORMAT = '%Y-%m-%dT%H:%M:%SZ'
 
+TIMEOUT = 10  # seconds
+
 API_V2_ENDPOINT = 'https://api.monday.com/v2'
 
 # Column Types


### PR DESCRIPTION
Adds supports for Issue #36.

Note that I'm getting some test errors but these seem to be due to work on Issue #37.

Traceback for all errors is the same:
```
File "/Users/alex/repos/moncli/moncli/entities/item.py", line 71, in get_column_values
    text = data['text']
KeyError: 'text'
```