### PR TITLE
Fix typo in the README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ $ pip3 install moncli
 Getting started with the moncli Python package is simple.  To begin, create a default __MondayClient__ istance using the following code below:
 ```
 >>> from moncli import client
->>> client.api_v2_key = api_v2_key
+>>> client.api_key_v2 = api_key_v2
 ```
 The __MondayClient__ object is the entry point for all client activities and includes functionality for board, item, tag, and user management.
 


### PR DESCRIPTION
The README had a typo and it's not obvious what's wrong when I tried to use the client.