### PR TITLE
Update simple.py to handle string representations of floats

### DIFF
--- a/moncli/column_value/simple.py
+++ b/moncli/column_value/simple.py
@@ -262,7 +262,7 @@ class NumberValue(SimpleNullValue):
     
     def _convert(self, value):
         if self.__isint(value):
-           return int(value)
+           return int(float(value))
         elif self.__isfloat(value):
            return float(value)
         


### PR DESCRIPTION
Currently if the value of a `NumberValue` is a string representation of a float (e.g. "95.0") then the `_isint()` function returns `True` and the `_convert()` function tries to cast it to an int. 

However (in Python 3.8 at least) you can't cast "95.0" directly to an `int` - you have to cast it to a `float` first.

This is just a fix to prevent the library breaking - it might make more sense to cast the number value to a float rather than an int, but that might also have unintended consequences.