### PR TITLE
hour field doesn't parse null value exception

### DIFF
--- a/moncli/column_value/complex.py
+++ b/moncli/column_value/complex.py
@@ -62,7 +62,10 @@ class HourValue(ComplexNullValue):
     allow_casts = (dict)
 
     def _convert(self, value):
-        return Hour(hour=value['hour'],minute=value['minute'])
+        try:
+            return Hour(hour=value['hour'],minute=value['minute'])
+        except KeyError:
+            return None
 
     def _cast(self, value):
         try:


### PR DESCRIPTION
Hour field seems to return non null value as well

{
                        "id": "publish_time",
                        "text": "",
                        "value": "{\"changed_at\":\"2022-10-27T06:32:49.604Z\"}"
                    },